### PR TITLE
chore: change bundle identifier from com.khalil.talky to com.talky.app

### DIFF
--- a/.AI/providers/talky.mjs
+++ b/.AI/providers/talky.mjs
@@ -4,7 +4,7 @@ import { homedir } from 'os';
 
 const SETTINGS_PATH = join(
   homedir(),
-  'Library/Application Support/com.khalil.talky/settings_store.json',
+  'Library/Application Support/com.talky.app/settings_store.json',
 );
 
 function loadSettings(envName) {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Talky",
   "version": "0.11.1",
-  "identifier": "com.khalil.talky",
+  "identifier": "com.talky.app",
   "build": {
     "beforeDevCommand": "npm run dev",
     "devUrl": "http://localhost:1420",


### PR DESCRIPTION
Decouple the application identifier from the original developer's name. Existing installations will need to migrate their data directory from ~/Library/Application Support/com.khalil.talky/ to com.talky.app/.