### PR TITLE
fix: move toaster to bottom-left to avoid Enhance Notes overla

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -134,7 +134,7 @@ function App() {
     <div className="h-screen flex flex-col select-none cursor-default">
       <Toaster
         theme="system"
-        position="bottom-right"
+        position="bottom-left"
         toastOptions={{
           unstyled: true,
           classNames: {


### PR DESCRIPTION
"The 'meeting finished' toast was covering ~90% of the Enhance Notes button. Moved Sonner Toaster from bottom-right to bottom-left in src/App.tsx.

Tested locally by ending a Teams call — toast now appears bottom-left, Enhance Notes button fully visible.

Of course there's the other option of moving it to "top-right". Tested both of them. The "bottom-left" looks nicer